### PR TITLE
4.0.0 Release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package pacmod2_game_control
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+4.0.0 (2021-12-21)
+------------------
 * Add missing includes to satisfy roslint
 * Convert to pacmod2_game_control
 * Contributors: Ian Colwell

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Changelog for package pacmod_game_control
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package pacmod2_game_control
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Add missing includes to satisfy roslint
+* Convert to pacmod2_game_control
+* Contributors: Ian Colwell
 
 3.0.2 (2020-04-13)
 ------------------

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pacmod2_game_control</name>
-  <version>3.0.2</version>
+  <version>4.0.0</version>
   <description>ROS Package for controlling the AStuff PACMod2 with a Joystick</description>
   <license>MIT</license>
 


### PR DESCRIPTION
Resolves #1 by releasing the first version of pacmod2_game_control.
This package is specifically for pacmod2 only and targets Noetic only.